### PR TITLE
Add alternative kernel config troubleshooting check in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ If you receive "permission denied" or similar errors:
    grep -E 'landlock|lsm=' /boot/config-$(uname -r)
    # alternatively, if there are no /boot/config-* files
    zgrep -iE 'landlock|lsm=' /proc/config.gz
+   # another alternate method
+   grep -iE 'landlock|lsm=' /lib/modules/$(uname -r)/config
    ```
    You should see `CONFIG_SECURITY_LANDLOCK=y` and `lsm=landlock,...` in the output
 4. For network restrictions, verify your kernel version is 6.8+ with Landlock ABI v5:

--- a/README.md
+++ b/README.md
@@ -194,9 +194,11 @@ If you receive "permission denied" or similar errors:
 3. Check that Landlock is supported and enabled on your system:
    ```bash
    grep -E 'landlock|lsm=' /boot/config-$(uname -r)
+   # alternatively, if there are no /boot/config-* files
+   zgrep -iE 'landlock|lsm=' /proc/config.gz
    ```
    You should see `CONFIG_SECURITY_LANDLOCK=y` and `lsm=landlock,...` in the output
-4. For network restrictions, verify your kernel version is 6.8+ with Landlock ABI v5:
+5. For network restrictions, verify your kernel version is 6.8+ with Landlock ABI v5:
    ```bash
    uname -r
    ```

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ If you receive "permission denied" or similar errors:
    zgrep -iE 'landlock|lsm=' /proc/config.gz
    ```
    You should see `CONFIG_SECURITY_LANDLOCK=y` and `lsm=landlock,...` in the output
-5. For network restrictions, verify your kernel version is 6.8+ with Landlock ABI v5:
+4. For network restrictions, verify your kernel version is 6.8+ with Landlock ABI v5:
    ```bash
    uname -r
    ```


### PR DESCRIPTION
My laptop (running openSUSE Aeon) doesn't have `/boot/config-$(uname -r)`, but it does have `/proc/config.gz` and `/lib/modules/$(uname -r)/config`.  I figure it'd be worthwhile to document those for other folks in a similar predicament.

(It'd be nice if all distros would agree on one place for the currently-running-kernel's config to live, but it doesn't seem like that's the case...)