### PR TITLE
test.sh: fix spurious command not found error

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -136,7 +136,7 @@ run_test() {
 # Test cases
 print_status "Starting test cases..."
 
-Basic access tests
+# Basic access tests
 run_test "Read-only access to file" \
     "./landrun --log-level debug --rox /usr --ro /lib --ro /lib64 --ro $RO_DIR -- cat $RO_DIR/test.txt" \
     0


### PR DESCRIPTION
Unrelated to this fix, I am wondering how some of these tests work without passing along $PATH. I get a bunch of command not found errors if I don't forward the env variable. Perhaps bash sets up $PATH on startup on your system?