### PR TITLE
fix: implement recursive dependency resolution

### DIFF
--- a/internal/elfdeps/testdata/liba.c
+++ b/internal/elfdeps/testdata/liba.c
@@ -1,0 +1,1 @@
+int a() { return 1; }

--- a/internal/elfdeps/testdata/libb.c
+++ b/internal/elfdeps/testdata/libb.c
@@ -1,0 +1,2 @@
+int a();
+int b() { return a(); }

--- a/internal/elfdeps/testdata/main.c
+++ b/internal/elfdeps/testdata/main.c
@@ -1,0 +1,2 @@
+int b();
+int main() { b(); return 0; }


### PR DESCRIPTION
As noted in https://github.com/Zouuup/landrun/pull/38#issuecomment-3239160491, the previous implementation of `GetLibraryDependencies` only performed a shallow scan of the binary's dependencies. This caused issues when a shared library itself had dependencies that were not directly listed in the main binary.

This commit refactors `GetLibraryDependencies` to use a work queue to perform a breadth-first search of the entire dependency tree. This ensures that all transitive dependencies are discovered.

A new test case, `TestRecursiveDependencies`, is added to verify the new behavior. This test is self-contained: it compiles a set of C source files with a nested dependency (`test_binary` -> `libb.so` -> `liba.so`) on the fly to ensure the recursive logic is working correctly. The test is skipped if `gcc` is not available in the environment.