### PR TITLE
elfdeps: look for 64 bit library matches first if binary is 64 bit

### DIFF
--- a/internal/elfdeps/elfdeps.go
+++ b/internal/elfdeps/elfdeps.go
@@ -16,6 +16,10 @@ var ldconfigRunner = func() ([]byte, error) {
 	return osexec.Command("ldconfig", "-p").Output()
 }
 
+// are we running a 64 bit binary? this is used when choosing the order
+// of library paths to look in (/lib vs /lib64)
+var is64bit bool
+
 // getLdmap runs `ldconfig -p` and returns a map of soname -> path.
 func getLdmap() map[string]string {
 	m := map[string]string{}
@@ -152,7 +156,10 @@ func resolveSingleSoname(soname string, rpaths []string, stdDirs []string, ldmap
 // standard library directories and falling back to parsing `ldconfig -p` output.
 func resolveSonames(needed []string, rpaths []string) []string {
 	resolved := map[string]string{}
-	stdDirs := []string{"/lib", "/lib64", "/usr/lib", "/usr/lib64", "/usr/local/lib"}
+	stdDirs := []string{"/lib", "/usr/lib", "/usr/local/lib"}
+	if is64bit {
+		stdDirs = append([]string{"/lib64", "/usr/lib64"}, stdDirs...)
+	}
 	var ldmap map[string]string
 
 	for _, soname := range needed {
@@ -206,6 +213,8 @@ func GetLibraryDependencies(binary string) ([]string, error) {
 				finalMap[interpPath] = struct{}{}
 				queue = append(queue, interpPath)
 			}
+			// also check if it is 64 or 32 bit
+			is64bit = f.Class == elf.ELFCLASS64
 		}
 
 		needed, rpaths := parseDynamic(f)


### PR DESCRIPTION
If you had 32 bits libraries in /lib, landrun --ldd would pick those before the 64 bit library in /lib64.

This MR just changes the lookup order if the binary we are running is 64 bit.

before:

```
$ ./landrun --log-level debug  --ldd --add-exec /bin/nc
[landrun:debug] 2025/12/03 11:33:45 Added executable path: /bin/nc
[landrun:debug] 2025/12/03 11:33:45 Added library paths: [/etc/ld.so.cache /lib64/ld-linux-x86-64.so.2 /lib64/libssl.so.3 /lib64/libpcap.so.1 /lib64/libibverbs.so.1 /lib64/libnl-3.so.200 /lib/libm.so.6 /lib/libc.so.6 /lib64/libcrypto.so.3 /lib/ld-linux.so.2 /lib/libz.so.1 /lib64/libnl-route-3.so.200 /lib/libgcc_s.so.1]
[landrun] 2025/12/03 11:33:45 Sandbox config: {ReadOnlyPaths:[] ReadWritePaths:[] ReadOnlyExecutablePaths:[/bin/nc /etc/ld.so.cache /lib64/ld-linux-x86-64.so.2 /lib64/libssl.so.3 /lib64/libpcap.so.1 /lib64/libibverbs.so.1 /lib64/libnl-3.so.200 /lib/libm.so.6 /lib/libc.so.6 /lib64/libcrypto.so.3 /lib/ld-linux.so.2 /lib/libz.so.1 /lib64/libnl-route-3.so.200 /lib/libgcc_s.so.1] ReadWriteExecutablePaths:[] BindTCPPorts:[] ConnectTCPPorts:[] BestEffort:false UnrestrictedFilesystem:false UnrestrictedNetwork:false}
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /bin/nc
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /etc/ld.so.cache
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib64/ld-linux-x86-64.so.2
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib64/libssl.so.3
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib64/libpcap.so.1
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib64/libibverbs.so.1
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib64/libnl-3.so.200
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib/libm.so.6
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib/libc.so.6
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib64/libcrypto.so.3
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib/ld-linux.so.2
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib/libz.so.1
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib64/libnl-route-3.so.200
[landrun:debug] 2025/12/03 11:33:45 Adding read-only executable path: /lib/libgcc_s.so.1
[landrun:debug] 2025/12/03 11:33:45 Applying Landlock restrictions
[landrun] 2025/12/03 11:33:45 Landlock restrictions applied successfully
[landrun] 2025/12/03 11:33:45 Executing: [/bin/nc]
/bin/nc: error while loading shared libraries: libm.so.6: cannot open shared object file: Permission denied
```

Notice it resolves four deps to their 32 bit version in /lib

After this MR:
```
$ ./landrun --log-level debug  --ldd --add-exec /bin/nc
[landrun:debug] 2025/12/03 12:04:28 Added executable path: /bin/nc
[landrun:debug] 2025/12/03 12:04:28 Added library paths: [/etc/ld.so.cache /lib64/libm.so.6 /lib64/libc.so.6 /lib64/libcrypto.so.3 /lib64/libpcap.so.1 /lib64/libibverbs.so.1 /lib64/ld-linux-x86-64.so.2 /lib64/libssl.so.3 /lib64/libz.so.1 /lib64/libnl-route-3.so.200 /lib64/libnl-3.so.200 /lib64/libgcc_s.so.1]
[landrun] 2025/12/03 12:04:28 Sandbox config: {ReadOnlyPaths:[] ReadWritePaths:[] ReadOnlyExecutablePaths:[/bin/nc /etc/ld.so.cache /lib64/libm.so.6 /lib64/libc.so.6 /lib64/libcrypto.so.3 /lib64/libpcap.so.1 /lib64/libibverbs.so.1 /lib64/ld-linux-x86-64.so.2 /lib64/libssl.so.3 /lib64/libz.so.1 /lib64/libnl-route-3.so.200 /lib64/libnl-3.so.200 /lib64/libgcc_s.so.1] ReadWriteExecutablePaths:[] BindTCPPorts:[] ConnectTCPPorts:[] BestEffort:false UnrestrictedFilesystem:false UnrestrictedNetwork:false}
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /bin/nc
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /etc/ld.so.cache
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libm.so.6
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libc.so.6
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libcrypto.so.3
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libpcap.so.1
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libibverbs.so.1
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/ld-linux-x86-64.so.2
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libssl.so.3
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libz.so.1
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libnl-route-3.so.200
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libnl-3.so.200
[landrun:debug] 2025/12/03 12:04:28 Adding read-only executable path: /lib64/libgcc_s.so.1
[landrun:debug] 2025/12/03 12:04:28 Applying Landlock restrictions
[landrun] 2025/12/03 12:04:28 Landlock restrictions applied successfully
[landrun] 2025/12/03 12:04:28 Executing: [/bin/nc]
Ncat: You must specify a host to connect to. QUITTING.
```

Now it works
