### PR TITLE
fix: use Restrict() to avoid REFER permission denial

### DIFF
--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -172,18 +172,24 @@ func Apply(cfg Config) error {
 		return nil
 	}
 
-	// Apply all rules at once
+	// Apply all rules in a single Restrict() call.
+	// Using separate RestrictPaths() and RestrictNet() calls creates two
+	// Landlock rulesets. RestrictNet() clears handledAccessFS, and since
+	// REFER is "always denied by default when not in handled_access_fs"
+	// (per kernel docs), the second ruleset would implicitly deny REFER.
+	// Using Restrict() with combined rules avoids this issue.
 	log.Debug("Applying Landlock restrictions")
+	var allRules []landlock.Rule
 	if !cfg.UnrestrictedFilesystem {
-		err := llCfg.RestrictPaths(file_rules...)
-		if err != nil {
-			return fmt.Errorf("failed to apply Landlock filesystem restrictions: %w", err)
-		}
+		allRules = append(allRules, file_rules...)
 	}
 	if !cfg.UnrestrictedNetwork {
-		err := llCfg.RestrictNet(net_rules...)
+		allRules = append(allRules, net_rules...)
+	}
+	if len(allRules) > 0 {
+		err := llCfg.Restrict(allRules...)
 		if err != nil {
-			return fmt.Errorf("failed to apply Landlock network restrictions: %w", err)
+			return fmt.Errorf("failed to apply Landlock restrictions: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Using separate `RestrictPaths()` and `RestrictNet()` calls creates two Landlock rulesets. go-landlock's `RestrictNet()` clears `handledAccessFS`, and since REFER is "always denied by default when not in handled_access_fs" (per kernel docs), the second ruleset implicitly denies REFER.

This caused cross-directory rename/link operations to fail with EXDEV even when the directory was specified with `--rw`.

Fix by using `Restrict()` with combined rules, which creates a single ruleset with both FS and network rules, preserving REFER permission.

Fixes #48

---
Generated by pi + Claude claude-opus-4-5