### PR TITLE
fix: fix hardlinking between different directories.

### DIFF
--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -172,15 +172,32 @@ func Apply(cfg Config) error {
 		return nil
 	}
 
-	// Apply all rules at once
+	// Apply all rules in a single Landlock layer to avoid creating multiple layers. Each additional
+	// layer implicitly denies LANDLOCK_ACCESS_FS_REFER even when handledAccessFS is 0, which breaks
+	// hardlinking across directories.
+	//
+	// See <https://docs.kernel.org/userspace-api/landlock.html#filesystem-flags> ):
+	// > “This is the only access right which is denied by default by any ruleset, even if the right
+	// > is not specified as handled at ruleset creation time. The only way to make a ruleset grant
+	// > this right is to explicitly allow it for a specific directory by adding a matching rule to
+	// > the ruleset.”
+	//
+	// When both FS and Net are restricted, we use `Restrict()` to keep everything in one layer. When
+	// only one is restricted, we can use `RestrictPaths()` or `RestrictNet()` which will completely
+	// allow the unrestricted one.
 	log.Debug("Applying Landlock restrictions")
-	if !cfg.UnrestrictedFilesystem {
+
+	if !cfg.UnrestrictedFilesystem && !cfg.UnrestrictedNetwork {
+		err := llCfg.Restrict(append(file_rules, net_rules...)...)
+		if err != nil {
+			return fmt.Errorf("failed to apply Landlock restrictions: %w", err)
+		}
+	} else if !cfg.UnrestrictedFilesystem {
 		err := llCfg.RestrictPaths(file_rules...)
 		if err != nil {
 			return fmt.Errorf("failed to apply Landlock filesystem restrictions: %w", err)
 		}
-	}
-	if !cfg.UnrestrictedNetwork {
+	} else if !cfg.UnrestrictedNetwork {
 		err := llCfg.RestrictNet(net_rules...)
 		if err != nil {
 			return fmt.Errorf("failed to apply Landlock network restrictions: %w", err)


### PR DESCRIPTION
Fixes a bug due to the kernel's special handling of the FSRefer access.

Previously landrun would restrict file paths with one call to `RestrictPaths()` and restrict network access with a second call to `RestrictNet()`.

The issue is that when we call `RestrictNet()`, it carries with it an implicit restriction on the FSRefer access. According to the [kernel docs](https://docs.kernel.org/userspace-api/landlock.html#filesystem-flags) on FSRefer:

> This is the only access right which is denied by default by any ruleset, even if the right is not specified as handled at ruleset creation time. The only way to make a ruleset grant this right is to explicitly allow it for a specific directory by adding a matching rule to the ruleset.

We get around this by making a single call to Restrict() instead of two separate calls, unless either the filesystem or network are unrestricted, in which case we just restrict the one that is still restricted with RestrictPaths() or RestrictNet().

Interestingly, even before this PR, running landrun with `--unrestrestricted-network` actually fixes the hardlink issue because it doesn't create the second landlock layer for the network access.

```
# This will fail in the previous version of landrun
landrun --rwx / ln somefile.txt somedir/link.txt
# This will succeed because we only create one landlock layer
landrun --rwx / --unrestrestricted-network ln somefile.txt somedir/link.txt
```

**AI usage disclosure:** DeepSeek v4 Flash was used to find the root cause of the issue. I have my [entire chat transcript](https://zicklag.github.io/ai-sessions/github-com-Zouuup-landrun-issues-55_1.html) public for transparency. You can see exactly how I prompted it, and all the models tool calls, thinking, etc. Nothing was redacted. By the end of the session I believe I understand the fix, and why it works, and I sign off on the code as having put my own full due dilligence into making sure it made sense to me and lined up with the kernel documentation as well as my own tests.

Fixes: #55