### PR TITLE
Fix ELF library resolution to prefer the binary's architecture.

### DIFF
--- a/internal/elfdeps/elfdeps.go
+++ b/internal/elfdeps/elfdeps.go
@@ -16,17 +16,181 @@ var ldconfigRunner = func() ([]byte, error) {
 	return osexec.Command("ldconfig", "-p").Output()
 }
 
-// are we running a 64 bit binary? this is used when choosing the order
-// of library paths to look in (/lib vs /lib64)
-var is64bit bool
+// knownMachineTags are architecture qualifiers that appear in `ldconfig -p`
+// output (e.g. "libc.so.6 (libc6,x86-64) => ...").
+var knownMachineTags = []string{
+	"x86-64",
+	"x32",
+	"AArch64",
+	"ARM",
+	"IA-64",
+	"PPC64",
+	"PPC",
+	"RISCV64",
+	"RISCV32",
+	"S390X",
+	"S390",
+	"SPARC64",
+	"SPARC",
+	"MIPS64",
+	"MIPS",
+}
 
-// getLdmap runs `ldconfig -p` and returns a map of soname -> path.
-func getLdmap() map[string]string {
+type ldEntry struct {
+	path string
+	info string // parenthetical flags from ldconfig, e.g. "libc6,x86-64"
+}
+
+// ldconfigMachineTag returns the ldconfig arch qualifier that should be
+// preferred when resolving libraries for the given ELF class/machine.
+// An empty string means "no machine qualifier" (typical for i386).
+func ldconfigMachineTag(class elf.Class, machine elf.Machine) string {
+	switch machine {
+	case elf.EM_X86_64:
+		if class == elf.ELFCLASS32 {
+			return "x32"
+		}
+		return "x86-64"
+	case elf.EM_AARCH64:
+		return "AArch64"
+	case elf.EM_ARM:
+		return "ARM"
+	case elf.EM_386:
+		return ""
+	case elf.EM_PPC64:
+		return "PPC64"
+	case elf.EM_PPC:
+		return "PPC"
+	case elf.EM_RISCV:
+		if class == elf.ELFCLASS64 {
+			return "RISCV64"
+		}
+		return "RISCV32"
+	case elf.EM_S390:
+		if class == elf.ELFCLASS64 {
+			return "S390X"
+		}
+		return "S390"
+	case elf.EM_IA_64:
+		return "IA-64"
+	case elf.EM_SPARCV9:
+		return "SPARC64"
+	case elf.EM_SPARC:
+		return "SPARC"
+	case elf.EM_MIPS:
+		if class == elf.ELFCLASS64 {
+			return "MIPS64"
+		}
+		return "MIPS"
+	default:
+		return ""
+	}
+}
+
+// standardLibDirs returns library directories to search for the given ELF arch,
+// including Debian/Ubuntu multiarch paths.
+func standardLibDirs(class elf.Class, machine elf.Machine) []string {
+	var dirs []string
+	switch {
+	case machine == elf.EM_X86_64 && class == elf.ELFCLASS64:
+		dirs = []string{
+			"/lib64", "/usr/lib64",
+			"/lib/x86_64-linux-gnu", "/usr/lib/x86_64-linux-gnu",
+		}
+	case machine == elf.EM_X86_64 && class == elf.ELFCLASS32: // x32
+		dirs = []string{"/libx32", "/usr/libx32"}
+	case machine == elf.EM_386:
+		dirs = []string{
+			"/lib32", "/usr/lib32",
+			"/lib/i386-linux-gnu", "/usr/lib/i386-linux-gnu",
+		}
+	case machine == elf.EM_AARCH64:
+		dirs = []string{
+			"/lib64", "/usr/lib64",
+			"/lib/aarch64-linux-gnu", "/usr/lib/aarch64-linux-gnu",
+		}
+	case machine == elf.EM_ARM:
+		dirs = []string{
+			"/lib/arm-linux-gnueabihf", "/usr/lib/arm-linux-gnueabihf",
+			"/lib/arm-linux-gnueabi", "/usr/lib/arm-linux-gnueabi",
+		}
+	case machine == elf.EM_RISCV && class == elf.ELFCLASS64:
+		dirs = []string{
+			"/lib64", "/usr/lib64",
+			"/lib/riscv64-linux-gnu", "/usr/lib/riscv64-linux-gnu",
+		}
+	case machine == elf.EM_PPC64:
+		dirs = []string{
+			"/lib64", "/usr/lib64",
+			"/lib/powerpc64le-linux-gnu", "/usr/lib/powerpc64le-linux-gnu",
+			"/lib/powerpc64-linux-gnu", "/usr/lib/powerpc64-linux-gnu",
+		}
+	case machine == elf.EM_S390 && class == elf.ELFCLASS64:
+		dirs = []string{
+			"/lib64", "/usr/lib64",
+			"/lib/s390x-linux-gnu", "/usr/lib/s390x-linux-gnu",
+		}
+	}
+	return append(dirs, "/lib", "/usr/lib", "/usr/local/lib")
+}
+
+func hasKnownMachineTag(info string) bool {
+	for _, tag := range knownMachineTags {
+		if tokenInInfo(info, tag) {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenInInfo(info, token string) bool {
+	if token == "" || info == "" {
+		return false
+	}
+	for _, part := range strings.Split(info, ",") {
+		if strings.TrimSpace(part) == token {
+			return true
+		}
+	}
+	return false
+}
+
+func pickLdEntry(entries []ldEntry, preferredTag string) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	if preferredTag != "" {
+		for _, e := range entries {
+			if tokenInInfo(e.info, preferredTag) {
+				return e.path
+			}
+		}
+	} else {
+		// Prefer entries without a machine qualifier (e.g. plain i386 "(libc6)").
+		for _, e := range entries {
+			if !hasKnownMachineTag(e.info) {
+				return e.path
+			}
+		}
+	}
+	// Fall back only when there is a single candidate, to avoid picking a
+	// library for the wrong architecture when several exist.
+	if len(entries) == 1 {
+		return entries[0].path
+	}
+	return ""
+}
+
+// getLdmap runs `ldconfig -p` and returns a map of soname -> path, preferring
+// entries that match preferredTag (from ldconfigMachineTag).
+func getLdmap(preferredTag string) map[string]string {
 	m := map[string]string{}
 	out, err := ldconfigRunner()
 	if err != nil {
 		return m
 	}
+
+	bySoname := map[string][]ldEntry{}
 	lines := strings.Split(string(out), "\n")
 	for _, line := range lines {
 		if !strings.Contains(line, "=>") {
@@ -46,10 +210,20 @@ func getLdmap() map[string]string {
 		if path == "" || soname == "" {
 			continue
 		}
-		if _, err := os.Stat(path); err == nil {
-			if _, exists := m[soname]; !exists {
-				m[soname] = path
+		info := ""
+		if i := strings.Index(left, "("); i >= 0 {
+			if j := strings.Index(left[i:], ")"); j >= 0 {
+				info = strings.TrimSpace(left[i+1 : i+j])
 			}
+		}
+		if _, err := os.Stat(path); err == nil {
+			bySoname[soname] = append(bySoname[soname], ldEntry{path: path, info: info})
+		}
+	}
+
+	for soname, entries := range bySoname {
+		if p := pickLdEntry(entries, preferredTag); p != "" {
+			m[soname] = p
 		}
 	}
 	return m
@@ -124,7 +298,7 @@ func normalizeRpaths(rpaths []string, origin string) []string {
 // resolveSingleSoname attempts to resolve a single soname using rpaths,
 // standard dirs and ldconfig fallback. It takes a pointer to ldmap so the
 // caller can lazily populate and reuse it.
-func resolveSingleSoname(soname string, rpaths []string, stdDirs []string, ldmap *map[string]string) string {
+func resolveSingleSoname(soname string, rpaths []string, stdDirs []string, preferredTag string, ldmap *map[string]string) string {
 	// check rpaths first
 	for _, rp := range rpaths {
 		candidate := filepath.Join(rp, soname)
@@ -143,7 +317,7 @@ func resolveSingleSoname(soname string, rpaths []string, stdDirs []string, ldmap
 
 	// fallback: consult parsed ldconfig map (populate lazily)
 	if *ldmap == nil {
-		*ldmap = getLdmap()
+		*ldmap = getLdmap(preferredTag)
 	}
 	if p, ok := (*ldmap)[soname]; ok {
 		return p
@@ -154,19 +328,17 @@ func resolveSingleSoname(soname string, rpaths []string, stdDirs []string, ldmap
 
 // resolveSonames attempts to resolve sonames to absolute paths using rpaths,
 // standard library directories and falling back to parsing `ldconfig -p` output.
-func resolveSonames(needed []string, rpaths []string) []string {
+func resolveSonames(needed []string, rpaths []string, class elf.Class, machine elf.Machine) []string {
 	resolved := map[string]string{}
-	stdDirs := []string{"/lib", "/usr/lib", "/usr/local/lib"}
-	if is64bit {
-		stdDirs = append([]string{"/lib64", "/usr/lib64"}, stdDirs...)
-	}
+	stdDirs := standardLibDirs(class, machine)
+	preferredTag := ldconfigMachineTag(class, machine)
 	var ldmap map[string]string
 
 	for _, soname := range needed {
 		if _, ok := resolved[soname]; ok {
 			continue
 		}
-		resolved[soname] = resolveSingleSoname(soname, rpaths, stdDirs, &ldmap)
+		resolved[soname] = resolveSingleSoname(soname, rpaths, stdDirs, preferredTag, &ldmap)
 	}
 
 	out := []string{}
@@ -205,7 +377,6 @@ func GetLibraryDependencies(binary string) ([]string, error) {
 			// (e.g. ld.so.cache). Ignore them.
 			continue
 		}
-		defer f.Close()
 
 		// The first binary in the queue is the main one; grab its interpreter
 		if curr == binary {
@@ -213,14 +384,13 @@ func GetLibraryDependencies(binary string) ([]string, error) {
 				finalMap[interpPath] = struct{}{}
 				queue = append(queue, interpPath)
 			}
-			// also check if it is 64 or 32 bit
-			is64bit = f.Class == elf.ELFCLASS64
 		}
 
 		needed, rpaths := parseDynamic(f)
 		origin := filepath.Dir(curr)
 		rpaths = normalizeRpaths(rpaths, origin)
-		libPaths := resolveSonames(needed, rpaths)
+		libPaths := resolveSonames(needed, rpaths, f.Class, f.Machine)
+		f.Close()
 
 		for _, p := range libPaths {
 			if _, ok := finalMap[p]; !ok {

--- a/internal/elfdeps/elfdeps_test.go
+++ b/internal/elfdeps/elfdeps_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -33,7 +34,7 @@ func TestParseAndResolveTrue(t *testing.T) {
 
 	origin := filepath.Dir(bin)
 	rpaths = normalizeRpaths(rpaths, origin)
-	paths := resolveSonames(needed, rpaths)
+	paths := resolveSonames(needed, rpaths, f.Class, f.Machine)
 	if paths == nil {
 		paths = []string{}
 	}
@@ -43,11 +44,22 @@ func TestParseAndResolveTrue(t *testing.T) {
 		t.Fatalf("interp path %s does not exist: %v", interp, err)
 	}
 
-	// If there are resolved library paths, they must exist
+	// If there are resolved library paths, they must exist and match the
+	// binary's architecture (not e.g. an x32 libc for an x86-64 binary).
 	for _, p := range paths {
 		if _, err := os.Stat(p); err != nil {
 			t.Fatalf("resolved library path %s does not exist: %v", p, err)
 		}
+		lib, err := elf.Open(p)
+		if err != nil {
+			continue
+		}
+		if lib.Class != f.Class || lib.Machine != f.Machine {
+			lib.Close()
+			t.Fatalf("resolved %s has class/machine %v/%v, want %v/%v",
+				p, lib.Class, lib.Machine, f.Class, f.Machine)
+		}
+		lib.Close()
 	}
 }
 
@@ -112,6 +124,13 @@ func TestGetLibraryDependencies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to find 'true' binary: %v", err)
 	}
+	f, err := elf.Open(bin)
+	if err != nil {
+		t.Fatalf("failed to open %s: %v", bin, err)
+	}
+	class, machine := f.Class, f.Machine
+	f.Close()
+
 	paths, err := GetLibraryDependencies(bin)
 	if err != nil {
 		t.Fatalf("GetLibraryDependencies failed: %v", err)
@@ -119,13 +138,25 @@ func TestGetLibraryDependencies(t *testing.T) {
 	if len(paths) == 0 {
 		t.Fatalf("expected non-empty dependency list for %s", bin)
 	}
-	// ensure returned paths are absolute and exist
+	// ensure returned paths are absolute, exist, and match the binary arch
 	for _, p := range paths {
 		if !filepath.IsAbs(p) {
 			t.Fatalf("expected absolute path, got %s", p)
 		}
 		if _, err := os.Stat(p); err != nil {
 			t.Fatalf("path %s does not exist: %v", p, err)
+		}
+		if strings.Contains(p, "libx32") && class == elf.ELFCLASS64 {
+			t.Fatalf("x86-64 binary resolved to x32 path %s", p)
+		}
+		lib, err := elf.Open(p)
+		if err != nil {
+			continue // e.g. ld.so.cache
+		}
+		mismatched := lib.Class != class || lib.Machine != machine
+		lib.Close()
+		if mismatched {
+			t.Fatalf("dependency %s does not match binary arch", p)
 		}
 	}
 }
@@ -149,11 +180,45 @@ func TestGetLdmapWithFakeOutput(t *testing.T) {
 		return []byte("libfake.so (libc6,x86-64) => " + tmp + "\n"), nil
 	}
 
-	m := getLdmap()
+	m := getLdmap("x86-64")
 	if got, ok := m["libfake.so"]; !ok {
 		t.Fatalf("expected libfake.so in map")
 	} else if got != tmp {
 		t.Fatalf("expected path %s, got %s", tmp, got)
+	}
+}
+
+func TestGetLdmapPrefersMatchingArch(t *testing.T) {
+	original := ldconfigRunner
+	defer func() { ldconfigRunner = original }()
+
+	tmpDir := t.TempDir()
+	x32Path := filepath.Join(tmpDir, "libc-x32.so.6")
+	x64Path := filepath.Join(tmpDir, "libc-x64.so.6")
+	for _, p := range []string{x32Path, x64Path} {
+		f, err := os.Create(p)
+		if err != nil {
+			t.Fatalf("failed to create %s: %v", p, err)
+		}
+		f.Close()
+	}
+
+	// x32 listed first — the old bug picked this for every arch.
+	ldconfigRunner = func() ([]byte, error) {
+		return []byte(
+			"libc.so.6 (libc6,x32) => " + x32Path + "\n" +
+				"libc.so.6 (libc6,x86-64) => " + x64Path + "\n",
+		), nil
+	}
+
+	m := getLdmap("x86-64")
+	if got := m["libc.so.6"]; got != x64Path {
+		t.Fatalf("expected x86-64 libc %s, got %s", x64Path, got)
+	}
+
+	m = getLdmap("x32")
+	if got := m["libc.so.6"]; got != x32Path {
+		t.Fatalf("expected x32 libc %s, got %s", x32Path, got)
 	}
 }
 
@@ -175,7 +240,7 @@ func TestResolveSonamesUsesLdmapFallback(t *testing.T) {
 
 	// needed contains a soname that won't be found in rpaths or std dirs
 	rpaths := normalizeRpaths([]string{}, tmpDir)
-	out := resolveSonames([]string{"libfake2.so"}, rpaths)
+	out := resolveSonames([]string{"libfake2.so"}, rpaths, elf.ELFCLASS64, elf.EM_X86_64)
 	if len(out) != 1 {
 		t.Fatalf("expected 1 resolved path, got %d", len(out))
 	}
@@ -202,7 +267,7 @@ func TestResolveSonamesOriginExpansion(t *testing.T) {
 
 	// rpath using $ORIGIN should resolve to tmpDir/lib
 	rpaths1 := normalizeRpaths([]string{"$ORIGIN/lib"}, tmpDir)
-	out := resolveSonames([]string{libName}, rpaths1)
+	out := resolveSonames([]string{libName}, rpaths1, elf.ELFCLASS64, elf.EM_X86_64)
 	if len(out) != 1 {
 		t.Fatalf("expected 1 resolved path for $ORIGIN, got %d", len(out))
 	}
@@ -212,7 +277,7 @@ func TestResolveSonamesOriginExpansion(t *testing.T) {
 
 	// relative rpath should also resolve against origin
 	rpaths2 := normalizeRpaths([]string{"lib"}, tmpDir)
-	out2 := resolveSonames([]string{libName}, rpaths2)
+	out2 := resolveSonames([]string{libName}, rpaths2, elf.ELFCLASS64, elf.EM_X86_64)
 	if len(out2) != 1 {
 		t.Fatalf("expected 1 resolved path for relative rpath, got %d", len(out2))
 	}


### PR DESCRIPTION
Avoid picking x32 (or other) libc from ldconfig when sandboxing x86-64 binaries by matching arch tags and searching multiarch lib dirs.